### PR TITLE
Ignoring beta failures.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ branches:
 jobs:
   fail_fast: true
   allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
 
   include:


### PR DESCRIPTION
ember-source@3.9.0-beta.1 causes failures due to computed changes. This has been reverted. Just waiting for ember-source@3.9.0-beta.2 to be released.